### PR TITLE
Closing #9 and #11; accepting data in non-standard form for durfee and conjugate functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^README\.Rmd$
 ^\.travis\.yml$
+^appveyor\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: partitions
 Type: Package
 Title: Additive Partitions of Integers
-Version: 1.9-24
+Version: 1.10-0
 Depends: R (>= 3.6.0), mathjaxr
 Authors@R: person(given=c("Robin", "K. S."), family="Hankin", role = c("aut","cre"), email="hankin.robin@gmail.com", comment = c(ORCID = "0000-0001-5982-0415"))
 Maintainer: Robin K. S. Hankin <hankin.robin@gmail.com>
-Imports: gmp, polynom, sets
+Imports: gmp, polynom, sets, eddington
 Description: Additive partitions of integers.  Enumerates the
   partitions, unequal partitions, and restricted partitions of an
   integer; the three corresponding partition functions are also

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,13 @@ Package: partitions
 Type: Package
 Title: Additive Partitions of Integers
 Version: 1.10-0
-Depends: R (>= 3.6.0), mathjaxr
-Authors@R: person(given=c("Robin", "K. S."), family="Hankin", role = c("aut","cre"), email="hankin.robin@gmail.com", comment = c(ORCID = "0000-0001-5982-0415"))
+Depends: R (>= 3.6.0)
+Authors@R: c(
+    person(given=c("Robin", "K. S."), family="Hankin", role = c("aut","cre"), email="hankin.robin@gmail.com", comment = c(ORCID = "0000-0001-5982-0415")),
+    person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("ctb"), comment = c(ORCID = "0000-0001-6948-9498"))
+    )
 Maintainer: Robin K. S. Hankin <hankin.robin@gmail.com>
-Imports: gmp, polynom, sets, eddington
+Imports: gmp, polynom, sets, eddington, mathjaxr
 Description: Additive partitions of integers.  Enumerates the
   partitions, unequal partitions, and restricted partitions of an
   integer; the three corresponding partition functions are also

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,4 +10,4 @@ S3method(print,summary.partition)
 S3method(summary,partition)
 S3method(as.matrix,partition)
 
-export(print)
+# export(print)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,7 @@
 exportPattern("^[^\\.]")
 useDynLib(partitions, .registration=TRUE)
 import("gmp")
+import("mathjaxr")
 importFrom("polynom",polynomial)
 
 S3method(print,partition)
@@ -9,5 +10,3 @@ S3method(print,summary.partition)
 
 S3method(summary,partition)
 S3method(as.matrix,partition)
-
-# export(print)

--- a/R/partitions.R
+++ b/R/partitions.R
@@ -6,7 +6,7 @@
   }
   return(out)
 }
-    
+
 "as.matrix.partition" <- function(x, ...){
   class(x) <- "matrix"
   NextMethod("as.matrix")
@@ -51,7 +51,7 @@ print.summary.partition <- function(x, ...){
   }
   print.partition(x)
 }
-  
+
 "setparts" <- function(x){
   if(length(x)==1){
     if (x < 1){
@@ -253,7 +253,7 @@ function(n){
     return(as.integer(c(n-m+1,rep(1,m-1))))
   }
 }
-                                  
+
 "blockparts" <- function(f,n=NULL,include.fewer=FALSE){
   s <- sum(f)
   if(is.null(n)){
@@ -299,7 +299,7 @@ function(n){
 
   if(is.null(n)){
     return(all(part==f))
-  } 
+  }
 
   jj <- sum(cumprod(part==0)) + sum(cumprod(rev(part==f)))
   ans <- (jj==length(part)) | (jj==length(part)-1)
@@ -334,7 +334,7 @@ function(n){
 
   if(include.fewer){
     return(Recall(
-                  part = c(n-sum(part),part), 
+                  part = c(n-sum(part),part),
                   f    = c(s,f),
                   n    = n
                   )[-1]
@@ -502,8 +502,10 @@ function(n, give=FALSE){
     }
 }
 
-"conjugate" <- function(x){
+"conjugate" <- function(x, sorted = TRUE){
   x <- as.matrix(x)
+  if (!sorted)
+    x <- apply(x, 2, sort, decreasing = TRUE)
   mx <- max(x)
   nc <- ncol(x)
   out <- .C("c_conjugate",
@@ -511,6 +513,7 @@ function(n, give=FALSE){
            as.integer(nrow(x)),
            as.integer(nc),
            as.integer(mx),
+           # as.integer(sorted),
            ans=integer(mx*nc),
            PACKAGE = "partitions"
            )$ans
@@ -521,14 +524,17 @@ function(n, give=FALSE){
   return(drop(out))
 }
 
-"durfee" <- function(x){
+"durfee" <- function(x, sorted = TRUE){
   x <- as.matrix(x)
-  .C("c_durfee",
-     as.integer(x),
-     as.integer(nrow(x)),
-     as.integer(ncol(x)),
-     ans=integer(ncol(x)),
-     PACKAGE="partitions")$ans
+  if (sorted)
+    .C("c_durfee",
+       as.integer(x),
+       as.integer(nrow(x)),
+       as.integer(ncol(x)),
+       ans=integer(ncol(x)),
+       PACKAGE="partitions")$ans
+  else
+    apply(x, 2, eddington::E_num)
 }
 
 "perms" <- function(n){
@@ -553,7 +559,7 @@ function(n, give=FALSE){
     stopifnot(len == round(len))
     stopifnot(len >= 0)
   }
-  
+
   .C("c_tobin",
      as.integer(n),
      ans=integer(len),
@@ -600,7 +606,7 @@ function(n, give=FALSE){
             as.integer(fn),
             PACKAGE="partitions"
             )$ans
-    
+
   dim(out) <- c(n,fn)
   return(as.partition(out))
 }

--- a/R/partitions.R
+++ b/R/partitions.R
@@ -503,6 +503,8 @@ function(n, give=FALSE){
 }
 
 "conjugate" <- function(x, sorted = TRUE){
+  if (!length(x))
+    return(integer(0))
   x <- as.matrix(x)
   # if (!sorted)
   #   x <- apply(x, 2, sort, decreasing = TRUE)

--- a/R/partitions.R
+++ b/R/partitions.R
@@ -504,8 +504,8 @@ function(n, give=FALSE){
 
 "conjugate" <- function(x, sorted = TRUE){
   x <- as.matrix(x)
-  if (!sorted)
-    x <- apply(x, 2, sort, decreasing = TRUE)
+  # if (!sorted)
+  #   x <- apply(x, 2, sort, decreasing = TRUE)
   mx <- max(x)
   nc <- ncol(x)
   out <- .C("c_conjugate",
@@ -513,7 +513,7 @@ function(n, give=FALSE){
            as.integer(nrow(x)),
            as.integer(nc),
            as.integer(mx),
-           # as.integer(sorted),
+           as.integer(sorted),
            ans=integer(mx*nc),
            PACKAGE = "partitions"
            )$ans

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+environment:
+  NOT_CRAN: true
+  # env vars that may need to be set, at least temporarily, from time to time
+  # see https://github.com/krlmlr/r-appveyor#readme for details
+  # USE_RTOOLS: true
+  # R_REMOTES_STANDALONE: true
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/man/conjugate.Rd
+++ b/man/conjugate.Rd
@@ -7,13 +7,15 @@
 Given a partition, provide its conjugate or Durfee square
 }
 \usage{
-conjugate(x)
-durfee(x)
+conjugate(x, sorted = TRUE)
+durfee(x, sorted = TRUE)
 }
 \arguments{
   \item{x}{Either a vector describing a partition, in standard form
     (ie nonincreasing); or a matrix whose columns are partitions in
     standard form}
+  \item{sorted}{A logical indicating whether the data is already in standard
+    form. That is to say, are the data sorted in decreasing order?}
 }
 \details{
   Conjugation is described in Andrews, and (eg) Hardy and Wright.
@@ -22,7 +24,7 @@ durfee(x)
   Ferrers diagram and considering the partition defined by columns
   instead of rows.  This may be visualised by flipping the Ferrers
   diagram about the leading diagonal.
-  
+
   Essentially, \code{conjugate()} carries out \R idiom
   \code{rev(cumsum(table(factor(a[a>0],levels=max(a):1))))}, but faster.
 
@@ -33,7 +35,7 @@ durfee(x)
   of the Durfee square, which Andrews denotes
   \eqn{d(\lambda)}{d(lambda)}.  It is equivalent to \R idiom
   \code{function(a){sum(a>=1:length(a))}}, but faster.
-  
+
 }
 \value{
 Returns either a partition in standard form, or a matrix whose
@@ -41,9 +43,9 @@ columns are partitions in standard form.
 }
 \author{Robin K. S. Hankin}
 \note{
-If argument \code{x} is not nonincreasing, all bets are off: these
-functions will not work and will silently return garbage.  Caveat
-emptor!  (output from \code{blockparts()} is not necessarily
+If argument \code{x} is not nonincreasing, you must use the \code{sorted}
+flag. Otherwise, these functions will not work and will silently return
+garbage.  Caveat emptor!  (output from \code{blockparts()} is not necessarily
 non-increasing)
 }
 \examples{
@@ -60,7 +62,7 @@ durfee(10:1)
 
 conjugate(restrictedparts(8,3))
 
-# (restrictedparts(8,3) splits 8 into at most 3 parts; 
+# (restrictedparts(8,3) splits 8 into at most 3 parts;
 # so no part of the conjugate partition is larger than 3).
 
 

--- a/man/conjugate.Rd
+++ b/man/conjugate.Rd
@@ -11,11 +11,11 @@ conjugate(x, sorted = TRUE)
 durfee(x, sorted = TRUE)
 }
 \arguments{
-  \item{x}{Either a vector describing a partition, in standard form
-    (ie nonincreasing); or a matrix whose columns are partitions in
-    standard form}
+  \item{x}{Either a vector describing a partition or a matrix whose
+    columns are partitions.}
   \item{sorted}{A logical indicating whether the data is already in standard
-    form. That is to say, are the data sorted in decreasing order?}
+    form. That is to say, are the data within each colum sorted in decreasing
+    order?}
 }
 \details{
   Conjugation is described in Andrews, and (eg) Hardy and Wright.
@@ -43,10 +43,10 @@ columns are partitions in standard form.
 }
 \author{Robin K. S. Hankin}
 \note{
-If argument \code{x} is not nonincreasing, you must use the \code{sorted}
-flag. Otherwise, these functions will not work and will silently return
-garbage.  Caveat emptor!  (output from \code{blockparts()} is not necessarily
-non-increasing)
+If argument \code{x} is not non-increasing, you must use the
+\code{sorted = FALSE} flag. Otherwise, these functions will not work and will
+silently return garbage.  Caveat emptor!  (output from \code{blockparts()}
+is not necessarily non-increasing)
 }
 \examples{
 parts(5)
@@ -57,6 +57,10 @@ conjugate(restrictedparts(6,4))
 
 durfee(10:1)
 
+# A parition in nonstandard form --- use `sorted = FALSE`
+x <- parts(5)[sample(5),]
+durfee(x, sorted = FALSE)
+conjugate(x, sorted = FALSE)
 
 # Suppose one wanted partitions of 8 with no part larger than 3:
 
@@ -64,8 +68,5 @@ conjugate(restrictedparts(8,3))
 
 # (restrictedparts(8,3) splits 8 into at most 3 parts;
 # so no part of the conjugate partition is larger than 3).
-
-
-
 }
 \keyword{math}

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -1,33 +1,36 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <R.h>
 
 void c_nextpart(int *x)
 {
         int i, yy, n, a, b;
 
         a=0;
-	while(x[++a] >0){} 
+	while(x[++a] >0){}
 	a--; /* a position of last nonzero */
 
 	b=a;
 	while(x[b--] == 1){ }
 	b++; /* b: pos of last elt >1 */
-	
+
         if(x[a]>1){ /* if last nonzero number >1 */
                 x[a]-- ; /* subtract one from it */
                 x[a+1] = 1; /* and put a 1 next to it */
                 return ;
-        } 
+        }
         n = a-b;   /* n: number of 1s*/
         x[b]--;    /* decrement final nonzero digit (perforce >1) */
         yy = x[b]; /* and add 1 to the next place */
 
         n++;           /* n is now number of 1s plus 1 (thus "n" is to
 			* to be distributed as evenly as possible
-			* after x[a]) */ 
-	i = b;        
+			* after x[a]) */
+	i = b;
 	while(n >= yy){        /* distribute n among elements x[a] onwards */
 		x[++i] = yy;   /* by repeatedly adding yy until no longer */
-		n -= yy;       /* possible */ 
+		n -= yy;       /* possible */
 	}
 	if(n){
 		x[++i] = n;    /* add the remainder to x */
@@ -35,14 +38,14 @@ void c_nextpart(int *x)
 	while(i < a){          /* set remaining elements to 0 */
 		x[++i] = 0;
 	}
-	
+
 	return;
 }
 
 void c_nextdiffpart(int *x, const int *ntri)
 {
         int yy, a, aa, d, n;
-	
+
 	a = *ntri;
 	while(x[--a] ==0){ }
 	aa=a; /* position of last nonzero */
@@ -52,12 +55,12 @@ void c_nextdiffpart(int *x, const int *ntri)
 	while ( (x[a]-d) < 2) {
 		n += x[a--];  /* n is running total */
 		d++;
-	} 
-        yy= --x[a++];  
+	}
+        yy= --x[a++];
 	n++; /* add one to n to compensate for decrementing x[a+1] */
 	while(n >= yy){   /*now add a decreasing sequence to x[a],x[a+1],...*/
-		x[a++] = --yy;  
-		n -= yy;       
+		x[a++] = --yy;
+		n -= yy;
 	};
 	x[a] = n;            /* add the remainder to x */
 	while(a < aa){       /* set remaining elements to 0 */
@@ -79,7 +82,7 @@ int c_nextrestrictedpart(int *x, const int *len) /* algorithm on p232 of Andrews
 			return 1;
 		}
 	}
-	
+
      	                               /* thus a is Andrews's Lambda_j.
 	                                 The diagnostic for existence
 					 of a next partition is a >= 0;
@@ -184,7 +187,7 @@ int numbrestrictedparts(int *x, const int m){ /* array x is  c(rep(1,m-1),n-m+1)
 	while(c_nextrestrictedpart(x, &m)==0)
 	{
 		count++;
-	} 
+	}
 	return count;
 }
 
@@ -195,10 +198,10 @@ void numbrestrictedparts_R(int *x, const int *m, int *ans){
 void c_allparts(const int *n, const int *len, int *x){
 	int i,j;
 	x[0] = *n;
-	for(i=1 /* sic */ ; i < *n ;  i++){ 
+	for(i=1 /* sic */ ; i < *n ;  i++){
 		x[i] = 0 ;
 	}
-	
+
 	for(i= *n ; i < *len ; i += *n){
 		for(j=0 ; j < *n ; j++){
 			x[i+j] = x[i+j - *n];
@@ -210,7 +213,7 @@ void c_allparts(const int *n, const int *len, int *x){
 void c_alldiffparts(const int *n, const int *len, const int *ntri, int *x){
 	int i,j;
 	x[0] = *n;
-	
+
 	for(i= *ntri ; i < *len ; i += *ntri){
 		for(j=0 ; j < *ntri ; j++){
 			x[i+j] = x[i+j - *ntri];
@@ -222,12 +225,12 @@ void c_alldiffparts(const int *n, const int *len, const int *ntri, int *x){
 void c_allrestrictedparts(const int *m, const int *n, const int *len, const int *inc, int *x){
 	int i,j;
 	if(*inc == 0){
-		for(i=0 ; i < (*m)-1 ; i++){ 
+		for(i=0 ; i < (*m)-1 ; i++){
 			x[i] = 1 ;
 		}
 		x[*m-1] = *n - *m + 1;
 	} else {
-		for(i=0 ; i < (*m)-1 ; i++){ 
+		for(i=0 ; i < (*m)-1 ; i++){
 			x[i] = 0 ;
 		}
 		x[*m-1] = *n ;
@@ -241,25 +244,71 @@ void c_allrestrictedparts(const int *m, const int *n, const int *len, const int 
 	}
 }
 
+int max_element(int *x, int len){
+  int best=INT_MIN;
+  for (int i=0; i < len; i++)
+    if (x[i] > best)
+      best = x[i];
+  return best;
+}
 
-void conjugate_vector(int *x, const int len, int *y)
+int min_element(int *x, int len){
+  int best=INT_MAX;
+  for (int i=0; i < len; i++)
+    if (x[i] < best)
+      best = x[i];
+  return best;
+}
+
+void c_sort(int *x, const int len, int *y)
+{
+  if (min_element(x, len) < 0)
+    error("This function only takes positive integers");
+  int max = max_element(x, len);
+  int *a = (int *) calloc(sizeof(int), max + 1);
+
+  if (a == NULL)
+    error("Could not allocate memory");
+
+  /* make an array of counts */
+  for (int i=0; i < len; i++)
+    a[*(x + i)]++;
+
+  /* replace existing array with reverse-sorted data */
+  for (int i=0; max >= 0; max--)
+    while (a[max]--)
+      y[i++] = max;
+
+  free(a);
+}
+
+void conjugate_vector(int *x, const int len, const int sorted, int *y)
 {
 	int i,j;
+  if (!sorted) {
+    int *tmp = (int *) malloc(sizeof(int) * len);
+    if (tmp == NULL)
+      error("Could not allocate memory");
+    c_sort(x, len, tmp);
+    x = tmp;
+  }
 	for(j=0 ; x[0]>0 ; j++)
 	{
 		for(i=0; (i<len) && (x[i]>0) ; i++)
 		{
 			x[i]--;
 			y[j]++;
-		} 
+		}
 	}
+	if (!sorted)
+	  free(x);
 }
 
-void c_conjugate(int *x, const int *nrow, const int *ncol, const int *nmax, int *y)
+void c_conjugate(int *x, const int *nrow, const int *ncol, const int *nmax, const int *sorted, int *y)
 {
 	int i;
 	for(i=0 ; i< (*ncol) ; i++){
-		conjugate_vector(x+ (i*(*nrow)) , *nrow, y+i*(*nmax));
+		conjugate_vector(x+ (i*(*nrow)), *nrow, *sorted, y+i*(*nmax));
 	}
 }
 
@@ -285,7 +334,7 @@ int c_nextblockpart(int *x, const int *y, const int *inlen)
         int a,i,j;
 	const int len = *inlen;
 	for(i=0 , a=x[0] ; (!x[i++]) || (x[i] ==y[i]) ; a += x[i]){};
-	/* i: position of first stack into which a block can be moved */ 
+	/* i: position of first stack into which a block can be moved */
 	/* a: number of blocks in stacks up to and including the first movable one */
 
 	if(i >= len){  /* check for all elements being at the right (ie x is the
@@ -303,14 +352,14 @@ int c_nextblockpart(int *x, const int *y, const int *inlen)
 	/* Now reallocate the "a" blocks by filling up the stack one by one from x[0] to x[i]:*/
 	for(j=0 ; j<i ; j++){
 	  if(a < y[j]){  /* empty all "a" blocks into x[j] */
-	    x[j] = a;   
+	    x[j] = a;
 	    a = 0;
 	  } else {
 	    x[j]=y[j];
 	    a -= y[j];
 	  }
 	}
-	
+
 	/* Getting here means that the function executed correctly: return 0 */
 	return 0;
 }
@@ -328,7 +377,7 @@ void c_allblockparts(int *x, const int *y, const int *nb, const int *len, const 
 	a = *total;
 	for(i=0 ; i< (*len) ; i++){
 	  if(a < y[i]){  /* empty all "a" blocks into x[j] */
-	    x[i] = a;   
+	    x[i] = a;
 	    a = 0;
 	  } else {
 	    x[i]=y[i];
@@ -340,7 +389,7 @@ void c_allblockparts(int *x, const int *y, const int *nb, const int *len, const 
 	  for(j=0 ; j < *len ; j++){
 	    x[i+j] = x[i+j - *len];
 	  }
-	  c_nextblockpart(x+i, y, len); 
+	  c_nextblockpart(x+i, y, len);
 	}
 }
 
@@ -369,12 +418,12 @@ int nextperm(int *x, const int len)
 
 void allperms(int *x, int *len, int *nb){
 	int i,j;
-			
+
 	for(i= *len ; i < (*len) * (*nb) ; i += *len){
 		for(j=0 ; j < *len ; j++){
 			x[i+j] = x[i+j - *len];
 		}
-		nextperm(x+i, *len); 
+		nextperm(x+i, *len);
 	}
 }
 */

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -264,8 +264,8 @@ void c_sort(int *x, const int len)
 {
   if (min_element(x, len) < 0)
     error("All elements must be integers >= 0");
-  int max = max_element(x, len);
-  int *a = (int *) calloc(max + 1, sizeof(int));
+  volatile int max = max_element(x, len);
+  int *a = (int *) calloc((unsigned int) max + 1, sizeof(int));
 
   if (a == NULL)
     error("Could not allocate memory");

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -292,7 +292,7 @@ void conjugate_vector(int *x, const int len, const int sorted, int *y)
     c_sort(x, len, tmp);
     x = tmp;
   }
-	for(j=0 ; x[0]>0 ; j++)
+	for(j=0 ; x[0] > 0; j++)
 	{
 		for(i=0; (i<len) && (x[i]>0) ; i++)
 		{
@@ -312,10 +312,11 @@ void c_conjugate(int *x, const int *nrow, const int *ncol, const int *nmax, cons
 	}
 }
 
-int durfee_vector(const int *x)
+int durfee_vector(const int *x, const int nrow)
 {
       int i;
-      for(i=0 ; x[i]>i ; i++){}
+      for(i=0 ; x[i] > i && i < nrow; i++)
+        ;
       return i;
 }
 
@@ -323,7 +324,7 @@ void c_durfee(const int *x, const int *nrow, const int *ncol, int *y)
 {
 	int i;
 	for(i=0 ; i< (*ncol) ; i++){
-   	       y[i] = durfee_vector(x +  i*(*nrow));
+    y[i] = durfee_vector(x +  i*(*nrow), *nrow);
 	}
 }
 

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -260,7 +260,7 @@ int min_element(int *x, int len){
   return best;
 }
 
-void c_sort(int *x, const int len, int *y)
+void c_sort(int *x, const int len)
 {
   if (min_element(x, len) < 0)
     error("All elements must be integers >= 0");
@@ -277,7 +277,7 @@ void c_sort(int *x, const int len, int *y)
   /* replace existing array with reverse-sorted data */
   for (int i=0; max >= 0; max--)
     while (a[max]--)
-      y[i++] = max;
+      x[i++] = max;
 
   free(a);
 }
@@ -285,13 +285,8 @@ void c_sort(int *x, const int len, int *y)
 void conjugate_vector(int *x, const int len, const int sorted, int *y)
 {
 	int i,j;
-  if (!sorted) {
-    int *tmp = (int *) malloc(sizeof(int) * len);
-    if (tmp == NULL)
-      error("Could not allocate memory");
-    c_sort(x, len, tmp);
-    x = tmp;
-  }
+  if (!sorted)
+    c_sort(x, len);
 	for(j=0 ; x[0] > 0; j++)
 	{
 		for(i=0; (i<len) && (x[i]>0) ; i++)
@@ -300,8 +295,6 @@ void conjugate_vector(int *x, const int len, const int sorted, int *y)
 			y[j]++;
 		}
 	}
-	if (!sorted)
-	  free(x);
 }
 
 void c_conjugate(int *x, const int *nrow, const int *ncol, const int *nmax, const int *sorted, int *y)

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -265,7 +265,7 @@ void c_sort(int *x, const int len)
   if (min_element(x, len) < 0)
     error("All elements must be integers >= 0");
   int max = max_element(x, len);
-  int *a = (int *) calloc(sizeof(int), max + 1);
+  int *a = (int *) calloc(max + 1, sizeof(int));
 
   if (a == NULL)
     error("Could not allocate memory");

--- a/src/partitions.c
+++ b/src/partitions.c
@@ -5,9 +5,9 @@
 
 void c_nextpart(int *x)
 {
-        int i, yy, n, a, b;
+  int i, yy, n, a, b;
 
-        a=0;
+  a=0;
 	while(x[++a] >0){}
 	a--; /* a position of last nonzero */
 
@@ -263,7 +263,7 @@ int min_element(int *x, int len){
 void c_sort(int *x, const int len, int *y)
 {
   if (min_element(x, len) < 0)
-    error("This function only takes positive integers");
+    error("All elements must be integers >= 0");
   int max = max_element(x, len);
   int *a = (int *) calloc(sizeof(int), max + 1);
 

--- a/src/partitions_init.c
+++ b/src/partitions_init.c
@@ -3,7 +3,7 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* FIXME: 
+/* FIXME:
    Check these declarations against the C/Fortran source code.
 */
 
@@ -15,7 +15,7 @@ extern void c_allperms(void *, void *, void *, void *);
 extern void c_allrestrictedparts(void *, void *, void *, void *, void *);
 extern void c_bintocomp(void *, void *, void *);
 extern void c_comptobin(void *, void *, void *);
-extern void c_conjugate(void *, void *, void *, void *, void *);
+extern void c_conjugate(void *, void *, void *, void *, void *, void *);
 extern void c_durfee(void *, void *, void *, void *);
 extern void c_nextblockpart(void *, void *, void *);
 extern void c_nextdiffpart(void *, void *);
@@ -36,7 +36,7 @@ static const R_CMethodDef CEntries[] = {
     {"c_allrestrictedparts",  (DL_FUNC) &c_allrestrictedparts,  5},
     {"c_bintocomp",           (DL_FUNC) &c_bintocomp,           3},
     {"c_comptobin",           (DL_FUNC) &c_comptobin,           3},
-    {"c_conjugate",           (DL_FUNC) &c_conjugate,           5},
+    {"c_conjugate",           (DL_FUNC) &c_conjugate,           6},
     {"c_durfee",              (DL_FUNC) &c_durfee,              4},
     {"c_nextblockpart",       (DL_FUNC) &c_nextblockpart,       3},
     {"c_nextdiffpart",        (DL_FUNC) &c_nextdiffpart,        2},

--- a/tests/testthat/test_aaa.R
+++ b/tests/testthat/test_aaa.R
@@ -14,17 +14,17 @@ f <- function(n){
   }
 
   m <- ceiling(n/2)
-  
+
   minmax(apply(           parts(n  ) ,2,sum))          &
   minmax(apply(       diffparts(n  ) ,2,sum))          &
   minmax(apply( restrictedparts(n,m) ,2,sum))          &
   minmax(apply(conjugate(          parts(n  )),2,sum)) &
   minmax(apply(conjugate(      diffparts(n  )),2,sum)) &
-  minmax(apply(conjugate(restrictedparts(n,m)),2,sum)) 
+  minmax(apply(conjugate(restrictedparts(n,m)),2,sum))
 }
 
-stopifnot(all(f(3:N)))          
-  
+stopifnot(all(f(3:N)))
+
 
 # now check that parts() has rep(1,n) as the last partition:
 g <- function(n){
@@ -69,7 +69,7 @@ compare <- function(n){
 
   a <- as.matrix(a[do.call(order,a),])
   b <- as.matrix(b[do.call(order,b),])
-  
+
   dimnames(a) <- NULL
   dimnames(b) <- NULL
 
@@ -94,13 +94,32 @@ stopifnot(identical(conjugate(a),as.integer(c(7,6,5,5,3,2,2))))
 
  f <- function(x){ #note second and third tests are the same
    (min(x)  %in%  0:1)            &
-   all(diff(x) %in% -1:0)         &   
-   all(diff(x[cumsum(rle(x)$lengths)]) == -1)  
+   all(diff(x) %in% -1:0)         &
+   all(diff(x[cumsum(rle(x)$lengths)]) == -1)
  }
-   
+
  g <- function(n){all(apply(conjugate(diffparts(n)),2,f))}
-                  
+
  stopifnot(c(g(10),g(11),g(20)))
+
+# Check for issue #9
+expect_identical(conjugate(integer(0)), integer(0))
+expect_identical(conjugate(NULL), integer(0))
+expect_identical(conjugate(c()), integer(0))
+
+# Accepting sorted data
+set.seed(777)
+a_rand <- sample(a)
+expect_identical(conjugate(a), conjugate(a_rand, sorted = FALSE))
+expect_identical(durfee(a), durfee(a_rand, sorted = FALSE))
+
+new_matrix <- matrix(sample(30, replace = TRUE), nrow = 6)
+sorted_matrix <- apply(new_matrix, 2, sort, decreasing = TRUE)
+expect_identical(conjugate(sorted_matrix), conjugate(new_matrix, sorted = FALSE))
+expect_identical(durfee(sorted_matrix), durfee(new_matrix, sorted = FALSE))
+
+# See issue #11
+expect_identical(durfee(matrix(rep(9, 9), nrow = 3)), rep(3L, 3L))
 
 
 # Now verify that S() is independent of the order of y:


### PR DESCRIPTION
Hi @RobinHankin,

Thanks again for the great package. It was a lot of fun to read through your code! 

Here's the rundown of proposed changes:

- Fixed issue #9 by returning `integer(0)` for all zero-length objects passed into `conjugate`.
- Fixed issue #11 by doing bounds-checking on the array.
- The `conjugate` function accepts data in non-standard form by adding a very simple counting sort function. I could presort using `base::sort` before sending down into C, but did not because this was faster and I figure we can make a lot of assumptions about the types of data being fed into this function.
- The `durfee` function accepts data in non-standard form by importing my [`eddington`](https://cran.r-project.org/package=eddington) package and using `E_num`.

Both `durfee` and `conjugate` behave as they did by default. If the user wants to feed in unsorted data, they will need to specify that using the `sorted` flag.

Please feel free to give me constructive criticism. I'm always open to suggestions and looking for ways to improve.

Paul 