### PR TITLE
Suppress TeX info in vignette for reproducibility

### DIFF
--- a/vignettes/setpartitions.Rnw
+++ b/vignettes/setpartitions.Rnw
@@ -5,6 +5,7 @@
 \usepackage{amsfonts}
 \usepackage{wasysym}
 \usepackage{xypic}
+\pdfsuppressptexinfo=-1
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% declarations for jss.cls %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Otherwise, the build path will appear in the `PTEX.FileName` metadata for the figures.